### PR TITLE
Better log display

### DIFF
--- a/spec/LoggerPluginSpec.php
+++ b/spec/LoggerPluginSpec.php
@@ -39,8 +39,8 @@ class LoggerPluginSpec extends ObjectBehavior
         $formatter->formatRequest($request)->willReturn('GET / 1.1');
         $formatter->formatResponse($response)->willReturn('200 OK 1.1');
 
-        $logger->info('Emit request: "GET / 1.1"', ['request' => $request])->shouldBeCalled();
-        $logger->info('Receive response: "200 OK 1.1" for request: "GET / 1.1"', ['request' => $request, 'response' => $response])->shouldBeCalled();
+        $logger->info("Sending request:\nGET / 1.1", ['request' => $request])->shouldBeCalled();
+        $logger->info("Received response:\n200 OK 1.1\n\nfor request:\nGET / 1.1", ['request' => $request, 'response' => $response])->shouldBeCalled();
 
         $next = function () use ($response) {
             return new FulfilledPromise($response->getWrappedObject());
@@ -55,8 +55,8 @@ class LoggerPluginSpec extends ObjectBehavior
 
         $exception = new NetworkException('Cannot connect', $request->getWrappedObject());
 
-        $logger->info('Emit request: "GET / 1.1"', ['request' => $request])->shouldBeCalled();
-        $logger->error('Error: "Cannot connect" when emitting request: "GET / 1.1"', ['request' => $request, 'exception' => $exception])->shouldBeCalled();
+        $logger->info("Sending request:\nGET / 1.1", ['request' => $request])->shouldBeCalled();
+        $logger->error("Error:\nCannot connect\nwhen sending request:\nGET / 1.1", ['request' => $request, 'exception' => $exception])->shouldBeCalled();
 
         $next = function () use ($exception) {
             return new RejectedPromise($exception);
@@ -76,8 +76,8 @@ class LoggerPluginSpec extends ObjectBehavior
 
         $exception = new HttpException('Forbidden', $request->getWrappedObject(), $response->getWrappedObject());
 
-        $logger->info('Emit request: "GET / 1.1"', ['request' => $request])->shouldBeCalled();
-        $logger->error('Error: "Forbidden" with response: "403 Forbidden 1.1" when emitting request: "GET / 1.1"', [
+        $logger->info("Sending request:\nGET / 1.1", ['request' => $request])->shouldBeCalled();
+        $logger->error("Error:\nForbidden\nwith response:\n403 Forbidden 1.1\n\nwhen sending request:\nGET / 1.1", [
             'request'   => $request,
             'response'  => $response,
             'exception' => $exception

--- a/src/LoggerPlugin.php
+++ b/src/LoggerPlugin.php
@@ -11,29 +11,15 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * Log request, response and exception for a HTTP Client.
+ * Log request, response and exception for an HTTP Client.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
 final class LoggerPlugin implements Plugin
 {
-    /**
-     * Logger to log request / response / exception for a http call.
-     *
-     * @var LoggerInterface
-     */
     private $logger;
-
-    /**
-     * Formats a request/response as string.
-     *
-     * @var Formatter
-     */
     private $formatter;
 
-    /**
-     * @param LoggerInterface $logger
-     */
     public function __construct(LoggerInterface $logger, Formatter $formatter = null)
     {
         $this->logger = $logger;
@@ -45,11 +31,11 @@ final class LoggerPlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
-        $this->logger->info(sprintf('Emit request: "%s"', $this->formatter->formatRequest($request)), ['request' => $request]);
+        $this->logger->info(sprintf("Sending request:\n%s", $this->formatter->formatRequest($request)), ['request' => $request]);
 
         return $next($request)->then(function (ResponseInterface $response) use ($request) {
             $this->logger->info(
-                sprintf('Receive response: "%s" for request: "%s"', $this->formatter->formatResponse($response), $this->formatter->formatRequest($request)),
+                sprintf("Received response:\n%s\n\nfor request:\n%s", $this->formatter->formatResponse($response), $this->formatter->formatRequest($request)),
                 [
                     'request' => $request,
                     'response' => $response,
@@ -60,7 +46,7 @@ final class LoggerPlugin implements Plugin
         }, function (Exception $exception) use ($request) {
             if ($exception instanceof Exception\HttpException) {
                 $this->logger->error(
-                    sprintf('Error: "%s" with response: "%s" when emitting request: "%s"', $exception->getMessage(), $this->formatter->formatResponse($exception->getResponse()), $this->formatter->formatRequest($request)),
+                    sprintf("Error:\n%s\nwith response:\n%s\n\nwhen sending request:\n%s", $exception->getMessage(), $this->formatter->formatResponse($exception->getResponse()), $this->formatter->formatRequest($request)),
                     [
                         'request' => $request,
                         'response' => $exception->getResponse(),
@@ -69,7 +55,7 @@ final class LoggerPlugin implements Plugin
                 );
             } else {
                 $this->logger->error(
-                    sprintf('Error: "%s" when emitting request: "%s"', $exception->getMessage(), $this->formatter->formatRequest($request)),
+                    sprintf("Error:\n%s\nwhen sending request:\n%s", $exception->getMessage(), $this->formatter->formatRequest($request)),
                     [
                         'request' => $request,
                         'exception' => $exception,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| Documentation   |
| License         | MIT


As the logger inlines HTTP request / response, it's really more readable
if the message use many lines by default.