### PR TITLE
prepare release 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
 
-## 1.1.0 - 2018-04-29
+## 1.1.0 - 2019-01-19
 
-- Start measuring the time it took to do the request. 
+- Support client-common 1.9 and 2
+- Measure the time it took to do the request. 
 
 ## 1.0.0 - 2016-05-05
 


### PR DESCRIPTION
it seems we intended to release something last april but then did not. 

any impediments to release this? client-common 1.9 allows php 5.4 and 7.0 so i think we should not change this here now.