### PR TITLE
Deduplicate request logs, couple request<>response by UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.3.0 - tomorrow
+
+- Deduplicate request log in response logs
+- Link request log with response log by UID
+
 ## 1.2.2 - 2021-07-26
 
 - Allow installation with psr/log version 2 and 3

--- a/spec/LoggerPluginSpec.php
+++ b/spec/LoggerPluginSpec.php
@@ -42,14 +42,24 @@ class LoggerPluginSpec extends ObjectBehavior
         $formatter->formatRequest($request)->willReturn('GET / 1.1');
         $formatter->formatResponse($response)->willReturn('200 OK 1.1');
 
-        $logger->info("Sending request:\nGET / 1.1", ['request' => $request])->shouldBeCalled();
         $logger->info(
-            "Received response:\n200 OK 1.1\n\nfor request:\nGET / 1.1",
+            "Sending request:\nGET / 1.1",
+            Argument::that(
+                function(array $context) use ($request) {
+                    return $context['request'] === $request->getWrappedObject()
+                        && is_string($context['uid'])
+                    ;
+                }
+            )
+        )->shouldBeCalled();
+        $logger->info(
+            "Received response:\n200 OK 1.1",
             Argument::that(
                 function(array $context) use ($request, $response) {
                     return $context['request'] === $request->getWrappedObject()
                         && $context['response'] === $response->getWrappedObject()
                         && is_int($context['milliseconds'])
+                        && is_string($context['uid'])
                     ;
                 }
             )
@@ -68,7 +78,16 @@ class LoggerPluginSpec extends ObjectBehavior
 
         $exception = new NetworkException('Cannot connect', $request->getWrappedObject());
 
-        $logger->info("Sending request:\nGET / 1.1", ['request' => $request])->shouldBeCalled();
+        $logger->info(
+            "Sending request:\nGET / 1.1",
+            Argument::that(
+                function(array $context) use ($request) {
+                    return $context['request'] === $request->getWrappedObject()
+                        && is_string($context['uid'])
+                        ;
+                }
+            )
+        )->shouldBeCalled();
         $logger->error(
             "Error:\nCannot connect\nwhen sending request:\nGET / 1.1",
             Argument::that(
@@ -76,6 +95,7 @@ class LoggerPluginSpec extends ObjectBehavior
                     return $context['request'] === $request->getWrappedObject()
                         && $context['exception'] === $exception
                         && is_int($context['milliseconds'])
+                        && is_string($context['uid'])
                     ;
                 }
             )
@@ -99,15 +119,25 @@ class LoggerPluginSpec extends ObjectBehavior
 
         $exception = new HttpException('Forbidden', $request->getWrappedObject(), $response->getWrappedObject());
 
-        $logger->info("Sending request:\nGET / 1.1", ['request' => $request])->shouldBeCalled();
+        $logger->info(
+            "Sending request:\nGET / 1.1",
+            Argument::that(
+                function(array $context) use ($request) {
+                    return $context['request'] === $request->getWrappedObject()
+                        && is_string($context['uid'])
+                    ;
+                }
+            )
+        )->shouldBeCalled();
         $logger->error(
-            "Error:\nForbidden\nwith response:\n403 Forbidden 1.1\n\nwhen sending request:\nGET / 1.1",
+            "Error:\nForbidden\nwith response:\n403 Forbidden 1.1",
             Argument::that(
                 function(array $context) use ($request, $response, $exception) {
                     return $context['request'] === $request->getWrappedObject()
                         && $context['response'] === $response->getWrappedObject()
                         && $context['exception'] === $exception
                         && is_int($context['milliseconds'])
+                        && is_string($context['uid'])
                     ;
                 }
             )

--- a/src/LoggerPlugin.php
+++ b/src/LoggerPlugin.php
@@ -38,7 +38,7 @@ final class LoggerPlugin implements Plugin
         return $next($request)->then(function (ResponseInterface $response) use ($request, $start, $uid) {
             $milliseconds = (int) round(hrtime(true) / 1E6 - $start);
             $this->logger->info(
-                sprintf("Received response:\n%s\n\nfor request:\n%s", $this->formatter->formatResponse($response), $this->formatter->formatRequest($request)),
+                sprintf("Received response:\n%s", $this->formatter->formatResponse($response)),
                 [
                     'request' => $request,
                     'response' => $response,
@@ -52,7 +52,7 @@ final class LoggerPlugin implements Plugin
             $milliseconds = (int) round((hrtime(true) / 1E6 - $start));
             if ($exception instanceof Exception\HttpException) {
                 $this->logger->error(
-                    sprintf("Error:\n%s\nwith response:\n%s\n\nwhen sending request:\n%s", $exception->getMessage(), $this->formatter->formatResponse($exception->getResponse()), $this->formatter->formatRequest($request)),
+                    sprintf("Error:\n%s\nwith response:\n%s", $exception->getMessage(), $this->formatter->formatResponse($exception->getResponse())),
                     [
                         'request' => $request,
                         'response' => $exception->getResponse(),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes
| BC breaks?      | no|
| Deprecations?   | no|
| Related tickets | fixes #18 
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT

Given

```yaml
httplug:
    clients:
        test:
            service: 'psr18.http_client'
            plugins:
                - httplug.plugin.logger
        test_with_error_handler:
            service: 'psr18.http_client'
            plugins:
                - httplug.plugin.logger
                - httplug.plugin.error
```

```php
$request = $this->requestFactory->createRequest('GET', 'https://httpbin.org/status/200');
$requestError = $this->requestFactory->createRequest('GET', 'https://httpbin.org/status/500');

$this->test->sendRequest($request);
$this->test->sendRequest($requestError);
$this->testWithErrorHandler->sendRequest($requestError);
```

```
18:54:46 INFO      [httplug] Sending request:
GET https://httpbin.org/status/200 1.1 ["request" => Nyholm\Psr7\Request { …},"uid" => "61fd6866755f45.27019150"]
18:54:46 INFO      [httplug] Received response:
200 OK 1.1 ["request" => Nyholm\Psr7\Request { …},"response" => Nyholm\Psr7\Response { …},"milliseconds" => 490,"uid" => "61fd6866755f45.27019150"]

18:54:46 INFO      [httplug] Sending request:
GET https://httpbin.org/status/500 1.1 ["request" => Nyholm\Psr7\Request { …},"uid" => "61fd6866ed29b5.48079388"]
18:54:47 INFO      [httplug] Received response:
500 Internal Server Error 1.1 ["request" => Nyholm\Psr7\Request { …},"response" => Nyholm\Psr7\Response { …},"milliseconds" => 129,"uid" => "61fd6866ed29b5.48079388"]

18:54:47 INFO      [httplug] Sending request:
GET https://httpbin.org/status/500 1.1 ["request" => Nyholm\Psr7\Request { …},"uid" => "61fd686718a270.30706898"]
18:54:47 ERROR     [httplug] Error:
Internal Server Error
with response:
500 Internal Server Error 1.1 ["request" => Nyholm\Psr7\Request { …},"response" => Nyholm\Psr7\Response { …},"exception" => Http\Client\Common\Exception\ServerErrorException { …},"milliseconds" => 107,"uid" => "61fd686718a270.30706898"]
```

For me this works OK, and could go as a patch release. But any next version works for us :+1: 