### PR TITLE
feat: add request uri to log context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.4.1 - unreleased
+## 1.5.0 - unreleased
 
 - Added request uri to log context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.4.1 - unreleased
+
+- Added request uri to log context
+
 ## 1.4.0 - 2024-10-31
 
 - Support PHP 8.3 and 8.4

--- a/src/LoggerPlugin.php
+++ b/src/LoggerPlugin.php
@@ -31,7 +31,13 @@ final readonly class LoggerPlugin implements Plugin
     {
         $start = hrtime(true) / 1E6;
         $uid = uniqid('', true);
-        $this->logger->info(sprintf("Sending request:\n%s", $this->formatter->formatRequest($request)), ['uid' => $uid]);
+        $this->logger->info(
+            sprintf("Sending request:\n%s", $this->formatter->formatRequest($request)),
+            [
+                'uid' => $uid,
+                'uri' => (string) $request->getUri(),
+            ]
+        );
 
         return $next($request)->then(function (ResponseInterface $response) use ($start, $uid, $request) {
             $milliseconds = (int) round(hrtime(true) / 1E6 - $start);
@@ -41,6 +47,7 @@ final readonly class LoggerPlugin implements Plugin
                 [
                     'milliseconds' => $milliseconds,
                     'uid' => $uid,
+                    'uri' => (string) $request->getUri(),
                 ]
             );
 
@@ -55,6 +62,7 @@ final readonly class LoggerPlugin implements Plugin
                         'exception' => $exception,
                         'milliseconds' => $milliseconds,
                         'uid' => $uid,
+                        'uri' => (string) $request->getUri(),
                     ]
                 );
             } else {
@@ -64,6 +72,7 @@ final readonly class LoggerPlugin implements Plugin
                         'exception' => $exception,
                         'milliseconds' => $milliseconds,
                         'uid' => $uid,
+                        'uri' => (string) $request->getUri(),
                     ]
                 );
             }

--- a/tests/LoggerPluginTest.php
+++ b/tests/LoggerPluginTest.php
@@ -30,7 +30,7 @@ final class LoggerPluginTest extends TestCase
         $response = new Response();
 
         $actualResponse = $this->plugin->handleRequest(
-            new Request('GET', 'http://example.com/'),
+            new Request('GET', 'http://example.com/path?query=value#fragment'),
             fn (RequestInterface $req) => new FulfilledPromise($response),
             function () {}
         )->wait();
@@ -38,8 +38,10 @@ final class LoggerPluginTest extends TestCase
         self::assertSame($response, $actualResponse);
 
         self::assertCount(2, $this->logger->logMessages);
-        self::assertSame("Sending request:\nGET http://example.com/ 1.1", $this->logger->logMessages[0]['info']);
+        self::assertSame("Sending request:\nGET http://example.com/path?query=value#fragment 1.1", $this->logger->logMessages[0]['info']);
+        self::assertSame('http://example.com/path?query=value#fragment', $this->logger->logMessages[0]['context']['uri']);
         self::assertSame("Received response:\n200 OK 1.1", $this->logger->logMessages[1]['info']);
+        self::assertSame('http://example.com/path?query=value#fragment', $this->logger->logMessages[1]['context']['uri']);
     }
 
     public function testLogsRequestException()
@@ -55,7 +57,9 @@ final class LoggerPluginTest extends TestCase
         } catch (NetworkException $exception) {
             self::assertCount(2, $this->logger->logMessages);
             self::assertSame("Sending request:\nGET http://example.com/ 1.1", $this->logger->logMessages[0]['info']);
+            self::assertSame('http://example.com/', $this->logger->logMessages[0]['context']['uri']);
             self::assertSame("Error:\nNetwork error\nwhen sending request:\nGET http://example.com/ 1.1", $this->logger->logMessages[1]['error']);
+            self::assertSame('http://example.com/', $this->logger->logMessages[1]['context']['uri']);
 
             throw $exception;
         }
@@ -75,8 +79,12 @@ final class LoggerPluginTest extends TestCase
             // Expected
             $this->assertCount(2, $this->logger->logMessages);
             $this->assertSame("Sending request:\nGET http://example.com/ 1.1", $this->logger->logMessages[0]['info']);
+            self::assertSame('http://example.com/', $this->logger->logMessages[0]['context']['uri']);
+
             // Ensure there's an error log for the exception
             $this->assertStringContainsString("Error:\nNot Found", $this->logger->logMessages[1]['error']);
+            self::assertSame('http://example.com/', $this->logger->logMessages[1]['context']['uri']);
+
             throw $exception;
         }
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Added request URI in the logging context


#### Why?

Having the request URI in the logging context will allow to identify for which request this response is and filtering by URI (instead of uid) when using different tools.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix) - not needed

